### PR TITLE
Add timezone configuration to use local zone

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,10 +3,15 @@ from flask import Flask, render_template, request, redirect, url_for, flash, ses
 from flask_sqlalchemy import SQLAlchemy
 from ics import Calendar
 import requests
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'calendar')
+
+# Time zone configuration. Defaults to UTC but can be overridden
+# with the TIMEZONE environment variable.
+LOCAL_TZ = ZoneInfo(os.environ.get("TIMEZONE", "UTC"))
 
 # Настройка базы данных
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///data.db')
@@ -16,7 +21,7 @@ db = SQLAlchemy(app)
 class ChatMessage(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.String(500))
-    timestamp = db.Column(db.DateTime, default=datetime.now(timezone.utc))
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(LOCAL_TZ))
 
 ICS_URL = "https://outlook.office365.com/owa/calendar/f049117561b64b3daa03684d3fdcbd7e@akb.nis.edu.kz/a5a59de348bf4d449e7757adbc6af4a114622577659288145240/calendar.ics"
 
@@ -33,8 +38,8 @@ def get_events():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
-    now = datetime.now(timezone.utc)
-    today_start = datetime(now.year, now.month, now.day, tzinfo=timezone.utc)
+    now = datetime.now(LOCAL_TZ)
+    today_start = datetime(now.year, now.month, now.day, tzinfo=LOCAL_TZ)
     today_end = today_start + timedelta(days=1)
 
     today_events = []
@@ -87,8 +92,8 @@ def get_events():
 
 @app.route('/chat')
 def get_chat():
-    now = datetime.now(timezone.utc)
-    start_of_day = datetime(now.year, now.month, now.day, tzinfo=timezone.utc)
+    now = datetime.now(LOCAL_TZ)
+    start_of_day = datetime(now.year, now.month, now.day, tzinfo=LOCAL_TZ)
 
     limit_time = now - timedelta(hours=24)
     ChatMessage.query.filter(ChatMessage.timestamp < limit_time).delete()


### PR DESCRIPTION
## Summary
- configure application timezone using `TIMEZONE` env variable
- adjust datetime usage to use local timezone for chat messages and calendar status

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684172c01ac0832296a744aa2ea1a8e0