### PR TITLE
Fix event datetime extraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,8 +54,8 @@ def get_events():
 
     for event in calendar.timeline.included(today_start, today_end):
         # 1) Извлекаем чистые datetime из ICS
-        start_dt = event.begin.dt
-        end_dt   = event.end.dt if event.end else start_dt
+        start_dt = event.begin.datetime
+        end_dt   = event.end.datetime if event.end else start_dt
 
         # 2) Если нет tzinfo — "надеваем" London, иначе конвертим
         if start_dt.tzinfo is None:


### PR DESCRIPTION
## Summary
- use `event.begin.datetime` and `event.end.datetime`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab170f744832287ef4d19ab8aed56