### PR TITLE
Adjust displayed chat timestamps by +1 hour

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,7 +138,10 @@ def get_chat():
         {
             "content": msg.content,
             # Convert timestamps back to the configured time zone when displaying
-            "timestamp": msg.timestamp.astimezone(LOCAL_TZ).strftime("%H:%M %d.%m.%Y")
+            # and add one hour to the display time as requested
+            "timestamp": (
+                msg.timestamp.astimezone(LOCAL_TZ) + timedelta(hours=1)
+            ).strftime("%H:%M %d.%m.%Y")
         } for msg in messages
     ])
 


### PR DESCRIPTION
## Summary
- display chat message times with a one-hour offset

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684abfd85484832289ed7252d8678f9e